### PR TITLE
Add some video extensions which don't have

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -83,6 +83,7 @@ module.exports = {
     mpga   : 'audio/mpeg',
     mp2    : 'audio/mpeg',
     mp3    : 'audio/mpeg',
+    mp4    : 'video/mp4',
     aif    : 'audio/x-aiff',
     aiff   : 'audio/x-aiff',
     aifc   : 'audio/x-aiff',
@@ -145,5 +146,10 @@ module.exports = {
     mxu    : 'video/vnd.mpegurl',
     avi    : 'video/x-msvideo',
     movie  : 'video/x-sgi-movie',
-    ice    : 'x-conference/x-cooltalk'
+    ice    : 'x-conference/x-cooltalk',
+    flv    : 'video/x-flv',
+    m3u8   : 'application/x-mpegURL',
+    ts     : 'video/MP2T',
+    '3gp'  : 'video/3gpp',
+    wmv    : 'video/x-ms-wmv'
 };


### PR DESCRIPTION
These types didn't coverd with `lib/types.js`, so I just add support for this.
- mp4
- 3gp
- flv
- wmv
- m3u8
- ts

If you feel free, please merge this PR and release a new version.